### PR TITLE
Integrate Mermaid.ink for diagram rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,41 +6,41 @@ Automated extraction and generation of Mermaid diagrams from markdown files.
 
 MermaidVisualizer is a Python tool that recursively scans directories for markdown files, extracts Mermaid diagram definitions, and automatically generates visual diagrams as image files (PNG/SVG). Perfect for documentation projects, technical wikis, and automated diagram generation pipelines.
 
+**Zero external dependencies required!** Uses the [mermaid.ink](https://mermaid.ink) API by default - no Node.js, Chrome, or Puppeteer needed.
+
 ## Features
 
+- **Zero Dependencies**: Uses mermaid.ink API by default - just install and run
 - **Automatic Extraction**: Finds all \`\`\`mermaid code blocks in markdown files
 - **Recursive Scanning**: Processes entire directory trees
 - **Multiple Formats**: Generate PNG or SVG diagrams
 - **Organized Output**: Creates structured output directory with clear naming
 - **Diagram Mapping**: Generates index showing all diagrams with source links
-- **Smart Caching**: Skips regeneration of unchanged diagrams
 - **Rich CLI**: Beautiful command-line interface with progress indicators
-- **Watch Mode**: Auto-regenerate diagrams when markdown files change
+- **Optional Local Rendering**: Use mermaid-cli for offline/bulk processing
 
 ## Installation
 
-### Slim Install (Recommended - No Node.js Required!)
-
-The slimmest way to install - uses the mermaid.ink API for rendering:
+### Standard Install (Recommended)
 
 ```bash
-# Install with API rendering support (just Python + requests)
-pip install mermaid-visualizer[api]
+# Install with pip
+pip install mermaid-visualizer
 
 # Or with UV
-uv tool install mermaid-visualizer[api]
+uv tool install mermaid-visualizer
 ```
 
-**That's it!** No Node.js, no Chrome, no Puppeteer. Use the `--api` flag:
+**That's it!** No Node.js, no Chrome, no Puppeteer. Just run:
 
 ```bash
-mermaid generate --api -i ./docs
-mermaid generate --api -i ./docs/architecture.md -f svg
+mermaid generate -i ./docs
+mermaid generate -i ./docs/architecture.md -f svg
 ```
 
-### Full Install (Local Rendering)
+### Local Rendering (Optional)
 
-For offline use or large diagrams, install with local mermaid-cli:
+For offline use or very large diagrams, you can optionally install mermaid-cli for local rendering:
 
 #### Prerequisites
 - Python 3.10+
@@ -48,9 +48,6 @@ For offline use or large diagrams, install with local mermaid-cli:
 - Chrome headless shell (for Puppeteer)
 
 ```bash
-# Install Python package with all features
-pip install mermaid-visualizer[full]
-
 # Install mermaid-cli
 npm install -g @mermaid-js/mermaid-cli
 
@@ -58,12 +55,11 @@ npm install -g @mermaid-js/mermaid-cli
 npx puppeteer browsers install chrome-headless-shell
 ```
 
-Now you can use local rendering (no `--api` flag needed):
+Then use the `--local` flag to render locally:
 
 ```bash
-mermaid generate --input-dir ./docs
-mermaid scan
-mermaid clean
+mermaid generate --local -i ./docs
+mermaid generate --local -s 3 -w 2400  # High-resolution output
 ```
 
 ### Development Install
@@ -88,32 +84,32 @@ uv pip install -e ".[full,dev]"
 ### Basic Commands
 
 ```bash
-# Generate diagrams using API (slim install)
-mermaid generate --api
-
-# Generate diagrams using local mermaid-cli (full install)
+# Generate diagrams (uses mermaid.ink API by default)
 mermaid generate
 
 # Specify input and output directories
-mermaid generate --api --input-dir ./docs --output-dir ./diagrams
+mermaid generate -i ./docs -o ./diagrams
 
 # Generate SVG instead of PNG
-mermaid generate --api --format svg
+mermaid generate -f svg
+
+# Use local mermaid-cli instead of API
+mermaid generate --local
 
 # High-resolution output (local rendering only)
-mermaid generate --scale 3 --width 2400
+mermaid generate --local -s 3 -w 2400
 
 # Scan without generating (dry run)
-mermaid scan --input-dir ./docs
+mermaid scan -i ./docs
 
 # Clean generated diagrams
-mermaid clean --output-dir ./diagrams
+mermaid clean -o ./diagrams
 ```
 
 If running from source:
 
 ```bash
-python -m src.cli generate --input-dir ./docs
+python -m src.cli generate -i ./docs
 ```
 
 ### Configuration
@@ -221,8 +217,8 @@ MermaidVisualizer/
 │   ├── __init__.py
 │   ├── cli.py            # CLI interface
 │   ├── extractor.py      # Mermaid block extraction
-│   ├── generator.py      # Diagram generation (local mermaid-cli)
-│   ├── api_renderer.py   # API rendering (mermaid.ink - slim install)
+│   ├── generator.py      # Diagram generation router
+│   ├── api_renderer.py   # API rendering (mermaid.ink - default)
 │   ├── file_handler.py   # File system operations
 │   └── gist_handler.py   # GitHub Gist support
 ├── tests/
@@ -245,21 +241,32 @@ Contributions welcome! Please feel free to submit a Pull Request.
 
 ## Troubleshooting
 
-### Chrome/Puppeteer Errors
+### API Rendering Issues (Default Mode)
+
+If diagrams fail to generate using the default API mode:
+
+- Check that your Mermaid syntax is valid on [Mermaid Live Editor](https://mermaid.live)
+- Ensure you have internet connectivity
+- Very large diagrams may exceed URL length limits - try `--local` mode
+- Rate limiting may occur with many requests - add delays or use `--local`
+
+### Local Rendering Issues (--local mode)
+
+These issues only apply when using `mermaid generate --local`:
+
+#### Chrome/Puppeteer Errors
 
 If you see errors about "Could not find Chrome" or Puppeteer:
 
 ```bash
-# Install Chrome headless shell (required for diagram rendering)
+# Install Chrome headless shell
 npx puppeteer browsers install chrome-headless-shell
 
 # Verify installation
 ls ~/.cache/puppeteer/
 ```
 
-The tool will automatically detect and use the installed Chrome binary.
-
-### Mermaid CLI Not Found
+#### Mermaid CLI Not Found
 
 If you see errors about `mmdc` or Mermaid CLI:
 
@@ -271,18 +278,10 @@ npm install -g @mermaid-js/mermaid-cli
 npx @mermaid-js/mermaid-cli --version
 ```
 
-### Diagram Generation Fails
-
-- Check that your Mermaid syntax is valid
-- Try the diagram on [Mermaid Live Editor](https://mermaid.live)
-- Ensure Chrome headless shell is installed (see above)
-- Check logs for specific error messages
-- Ensure Node.js is installed
-
 ## Roadmap
 
-- [x] API mode for cloud rendering (mermaid.ink)
-- [x] Slim install option (no Node.js/Chrome required)
+- [x] API mode for cloud rendering (mermaid.ink) - now the default!
+- [x] Zero-dependency install (no Node.js/Chrome required)
 - [ ] Batch processing optimization
 - [ ] Custom theme support
 - [ ] Docker container for isolated execution

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,18 +24,18 @@ classifiers = [
 dependencies = [
     "click>=8.1.0",
     "rich>=13.7.0",
+    "requests>=2.31.0",
 ]
 
 [project.optional-dependencies]
-# Slim install with API rendering (no Node.js/Chrome needed)
-api = [
-    "requests>=2.31.0",
+# Local rendering with mermaid-cli (requires Node.js/Chrome)
+local = [
+    "pyyaml>=6.0",
 ]
-# Full install with all features
+# Full install with all optional features
 full = [
     "pyyaml>=6.0",
     "watchdog>=3.0.0",
-    "requests>=2.31.0",
 ]
 # Development dependencies
 dev = [

--- a/src/api_renderer.py
+++ b/src/api_renderer.py
@@ -1,9 +1,9 @@
 """
 Mermaid.ink API-based diagram renderer.
 
-This module provides a zero-dependency alternative to mermaid-cli by using
-the mermaid.ink public API for rendering diagrams. This enables a slim
-installation that doesn't require Node.js, Chrome, or Puppeteer.
+This module provides the default rendering backend using the mermaid.ink
+public API. This approach requires zero external dependencies beyond Python
+packages - no Node.js, Chrome, or Puppeteer needed.
 
 Uses Rich for beautiful console output and progress feedback.
 
@@ -73,8 +73,8 @@ def generate_diagram_api(
         import requests
     except ImportError:
         logger.error(
-            "The 'requests' package is required for API rendering. "
-            "Install with: pip install mermaid-visualizer[api]"
+            "The 'requests' package is required but not found. "
+            "Install with: pip install mermaid-visualizer"
         )
         return False
 

--- a/src/generator.py
+++ b/src/generator.py
@@ -3,8 +3,8 @@ Mermaid diagram generator module.
 
 This module provides functionality to generate PNG and SVG diagrams from Mermaid syntax.
 Supports two rendering backends:
-1. Local: mermaid-cli (requires Node.js, Chrome/Puppeteer)
-2. API: mermaid.ink (requires only 'requests' package - slim install)
+1. API: mermaid.ink (default - zero external dependencies)
+2. Local: mermaid-cli (optional - requires Node.js, Chrome/Puppeteer)
 
 Uses Rich for beautiful console output and progress feedback.
 """
@@ -24,18 +24,18 @@ logger = logging.getLogger(__name__)
 # Console for rich output
 console = Console()
 
-# Global flag for API mode
-_use_api_mode = False
+# Global flag for API mode (default: True - uses mermaid.ink)
+_use_api_mode = True
 
 
 def set_api_mode(enabled: bool) -> None:
-    """Enable or disable API rendering mode."""
+    """Enable or disable API rendering mode (API is default)."""
     global _use_api_mode
     _use_api_mode = enabled
     if enabled:
-        logger.info("Using mermaid.ink API for diagram rendering (slim mode)")
+        logger.debug("Using mermaid.ink API for diagram rendering")
     else:
-        logger.debug("Using local mermaid-cli for diagram rendering")
+        logger.info("Using local mermaid-cli for diagram rendering")
 
 
 def is_api_mode() -> bool:


### PR DESCRIPTION
- Move requests from optional to required dependency
- Change default rendering mode from local mermaid-cli to mermaid.ink API
- Replace --api flag with --local flag (inverted logic)
- Update CLI help text and examples for API-first approach
- Update README with simplified installation instructions
- Users no longer need Node.js, Chrome, or Puppeteer by default

BREAKING CHANGE: The --api flag is now removed. Use --local to opt into local mermaid-cli rendering instead.